### PR TITLE
chore(x/vaas/consumer): remove fabricated `staking.Params` response fields

### DIFF
--- a/x/vaas/consumer/keeper/grpc_staking_query.go
+++ b/x/vaas/consumer/keeper/grpc_staking_query.go
@@ -20,18 +20,23 @@ func NewStakingQueryServer(k *Keeper) StakingQueryServer {
 	return StakingQueryServer{keeper: k}
 }
 
-// Params returns staking params - required by Hermes for IBC client creation
+// Params returns the subset of staking params that have a meaningful value on a
+// VAAS consumer chain. The endpoint exists so IBC relayers (e.g. Hermes,
+// ts-relayer) can read UnbondingTime when deriving the trusting_period of a
+// Tendermint light client targeting this chain.
+//
+// Consumer chains have no local validator selection, no local bonding, and no
+// local commission — the active set is dictated by the provider via VSC
+// packets. The remaining staking.Params fields (BondDenom, MaxValidators,
+// MaxEntries, MinCommissionRate) are therefore left at their zero values
+// rather than fabricated, so callers are not misled.
 func (s StakingQueryServer) Params(goCtx context.Context, req *stakingtypes.QueryParamsRequest) (*stakingtypes.QueryParamsResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 	params := s.keeper.GetConsumerParams(ctx)
 
-	// Return staking-compatible params with unbonding period from consumer params
 	stakingParams := stakingtypes.Params{
 		UnbondingTime:     params.UnbondingPeriod,
-		MaxValidators:     100,
-		MaxEntries:        7,
 		HistoricalEntries: uint32(params.HistoricalEntries),
-		BondDenom:         "uatone",
 		MinCommissionRate: math.LegacyZeroDec(),
 	}
 

--- a/x/vaas/consumer/keeper/grpc_staking_query_test.go
+++ b/x/vaas/consumer/keeper/grpc_staking_query_test.go
@@ -1,0 +1,50 @@
+package keeper_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"cosmossdk.io/math"
+
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+
+	testkeeper "github.com/allinbits/vaas/testutil/keeper"
+	consumerkeeper "github.com/allinbits/vaas/x/vaas/consumer/keeper"
+	vaastypes "github.com/allinbits/vaas/x/vaas/types"
+)
+
+// TestStakingQueryServerParams asserts that the staking.Params query handler
+// exposed by the consumer module:
+//   - reflects the consumer's UnbondingPeriod and HistoricalEntries from
+//     ConsumerParams, which IBC relayers rely on to derive trusting_period;
+//   - leaves BondDenom, MaxValidators, MaxEntries, and MinCommissionRate at
+//     their zero values, since VAAS consumer chains have no local bonding,
+//     validator selection, or commission.
+func TestStakingQueryServerParams(t *testing.T) {
+	consumerKeeper, ctx, ctrl, _ := testkeeper.GetConsumerKeeperAndCtx(t, testkeeper.NewInMemKeeperParams(t))
+	defer ctrl.Finish()
+
+	consumerKeeper.SetParams(ctx, vaastypes.NewParams(
+		true,
+		vaastypes.DefaultVAASTimeoutPeriod,
+		1234,
+		13*24*time.Hour,
+	))
+
+	server := consumerkeeper.NewStakingQueryServer(&consumerKeeper)
+	resp, err := server.Params(ctx, &stakingtypes.QueryParamsRequest{})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	// Real, VAAS-owned values pass through.
+	require.Equal(t, 13*24*time.Hour, resp.Params.UnbondingTime)
+	require.Equal(t, uint32(1234), resp.Params.HistoricalEntries)
+
+	// Fields that have no meaning on a consumer chain must not be fabricated.
+	require.Equal(t, "", resp.Params.BondDenom)
+	require.Equal(t, uint32(0), resp.Params.MaxValidators)
+	require.Equal(t, uint32(0), resp.Params.MaxEntries)
+	require.True(t, resp.Params.MinCommissionRate.Equal(math.LegacyZeroDec()))
+}


### PR DESCRIPTION
The consumer module registers a stub `cosmos.staking.v1beta1.Query/Params` handler so IBC relayers can read `UnbondingTime` when deriving the `trusting_period` of a Tendermint light client targeting the consumer chain.

The stub used to fill in the rest of the response with hardcoded values, but they are fictional and misleading. On top of that, they are essentially not needed. Removing these hard-coded values to clean-up the code. Added also a test for regression, although it could be arguably "too much".

A second-degree consideration here: why are we providing this stub? I guess because `ts-relayer` doesn't have a "vaas mode" to read the required values directly from querying the consumer module's params? The `interchain-security` implementation doesn't provide this stub.